### PR TITLE
Fix example: add gradle's google repository

### DIFF
--- a/SpruceExample/android/build.gradle
+++ b/SpruceExample/android/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'


### PR DESCRIPTION
Fix example build.

A problem occurred configuring root project 'SpruceExample'.
> Could not resolve all files for configuration ':classpath'.
   > Could not find com.android.tools.build:gradle:3.0.1.
     Searched in the following locations:
         https://jcenter.bintray.com/com/android/tools/build/gradle/3.0.1/gradle-3.0.1.pom
         https://jcenter.bintray.com/com/android/tools/build/gradle/3.0.1/gradle-3.0.1.jar_